### PR TITLE
Moving super agent back to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "change-case": "^2.3.0",
     "deepmerge": "^3.2.0",
     "lodash.get": "^4.4.2"
+    "superagent": "^5.1.1",
   },
   "peerDependencies": {
-    "superagent": "^5.1.1",
     "superagent-proxy": "^3.0.0"
   }
 }


### PR DESCRIPTION
As the following module is throwing error on transitive packages i.e as auth0 requires react-facade its throwing error one quick solution might be to move that back to  dependencies